### PR TITLE
Adding missing option to TunnelOptions typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,6 +31,11 @@ export interface TunnelOptions {
    * @default false
    */
   autoClose: boolean;
+  /*
+   * specifies if the tunnel should reconnect on error
+   * @default false
+  */
+  reconnectOnError: boolean;
 }
 
 /**


### PR DESCRIPTION
Looking through the code, noticed this typing was missing, but the code already supports reconnect on error